### PR TITLE
refactor: explicitly define global namespace, block `globals()`

### DIFF
--- a/service/py.py
+++ b/service/py.py
@@ -63,6 +63,11 @@ def load(uri):
     exec get(uri) in load.module.__dict__
     return load.module
 
+
+SAFER_BUILTINS = dict(__builtins__)
+del SAFER_BUILTINS['globals']
+
+
 class Main(base.RequestHandler):
 
     def get(self, *args):
@@ -73,9 +78,9 @@ class Main(base.RequestHandler):
         sys.stderr = output
         try:
             try:
-                output.write(str(eval(command)))
+                output.write(str(eval(command, {'__builtins__': SAFER_BUILTINS})))
             except SyntaxError:
-                exec(command)
+                exec(command, {'__builtins__': SAFER_BUILTINS})
             output.seek(0)
             self.ok(output.readline())
         except Exception, error:


### PR DESCRIPTION
This PR serves to prevent "attacks" where the global namespace is overwritten by commands like `.py globals()['sys'] = 'asdf'`. It also facilitates simple removal of additional objects from the global namespace that should not be exposed to a `.py` command. 